### PR TITLE
Ensure schema initialization is reusable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install
 bun install
 ```
 
-3) Ejecuta la migración (crea la base de datos local en `.data/db.sqlite`):
+3) Ejecuta la migración (crea la base de datos local en `.data/db.sqlite` o inicializa tu instancia de Turso manualmente):
 - Con npm:
 ```
 npm run migrate
@@ -43,6 +43,8 @@ npm run migrate
 ```
 bun run scripts/migrate.ts
 ```
+
+   - Si usas Turso, exporta `TURSO_DATABASE_URL` y `TURSO_AUTH_TOKEN` y ejecuta este script una única vez contra la instancia remota para crear la tabla e índice.
 
 4) Arranca el entorno de desarrollo:
 - Con npm:

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,30 +1,19 @@
-import { getDb, initDb } from '../src/lib/db.js';
+import { ensureSchema } from '../src/lib/db.js';
 import fs from 'node:fs';
 import path from 'node:path';
 
 async function main() {
-  // Ensure .data folder exists when using local SQLite
-  const dataDir = path.join(process.cwd(), '.data');
-  if (!fs.existsSync(dataDir)) {
-    fs.mkdirSync(dataDir, { recursive: true });
+  const usingTurso = Boolean(process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN);
+
+  if (!usingTurso) {
+    // Ensure .data folder exists when using local SQLite
+    const dataDir = path.join(process.cwd(), '.data');
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
   }
-  await initDb();
-  const db = getDb();
 
-  await db.execute(`
-    CREATE TABLE IF NOT EXISTS appointments (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      date TEXT NOT NULL, -- YYYY-MM-DD (lunes a viernes)
-      name TEXT NOT NULL,
-      phone TEXT,
-      notes TEXT,
-      created_at TEXT DEFAULT (datetime('now'))
-    );
-  `);
-
-  await db.execute(`
-    CREATE INDEX IF NOT EXISTS idx_appointments_date ON appointments(date);
-  `);
+  await ensureSchema({ force: true });
 
   console.log('Migration completed.');
 }

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -1,10 +1,11 @@
 import type { APIRoute } from 'astro';
-import { getDb } from '@/lib/db';
+import { ensureSchema, getDb } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
 
 export const PUT: APIRoute = async ({ params, request }) => {
   const authRes = await requireAuth(request);
   if (authRes) return authRes;
+  await ensureSchema();
   const db = getDb();
   const id = Number(params.id);
   const body = await request.json();
@@ -21,6 +22,7 @@ export const PUT: APIRoute = async ({ params, request }) => {
 export const DELETE: APIRoute = async ({ params, request }) => {
   const authRes = await requireAuth(request);
   if (authRes) return authRes;
+  await ensureSchema();
   const db = getDb();
   const id = Number(params.id);
   const res = await db.execute({ sql: 'DELETE FROM appointments WHERE id = ?', args: [id] });

--- a/src/pages/api/appointments/index.ts
+++ b/src/pages/api/appointments/index.ts
@@ -1,9 +1,10 @@
 import type { APIRoute } from 'astro';
-import { getDb } from '@/lib/db';
+import { ensureSchema, getDb } from '@/lib/db';
 import { dayjs } from '@/lib/utils/date';
 import { requireAuth } from '@/lib/auth';
 
 export const GET: APIRoute = async ({ request }) => {
+  await ensureSchema();
   const db = getDb();
   const url = new URL(request.url);
   const month = url.searchParams.get('month'); // YYYY-MM
@@ -55,6 +56,7 @@ export const GET: APIRoute = async ({ request }) => {
 export const POST: APIRoute = async ({ request }) => {
   const authRes = await requireAuth(request);
   if (authRes) return authRes;
+  await ensureSchema();
   const db = getDb();
   const data = await request.json();
   const { date, name, phone, notes } = data as { date: string; name: string; phone?: string; notes?: string };


### PR DESCRIPTION
## Summary
- add an `ensureSchema` helper in the database layer so local SQLite deployments can lazily create the table and index
- invoke `ensureSchema` from the appointments API handlers before querying when no Turso credentials are provided
- reuse the helper from the migration script and document the Turso one-time migration requirement in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc5f050ac48323bcba87a8e489f87c